### PR TITLE
Fixing the ci file and adding back fixes for the runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 image: ruby:2.3
 
-variables: 
+variables:
   JEKYLL_ENV: production
   LC_ALL: C.UTF-8
 
@@ -14,7 +14,7 @@ pages:
   artifacts:
     paths:
       - public
-    only:
-      - master
-    tags:
-      - pages
+  only:
+    - master
+  tags:
+    - pages

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'jekyll'
-gem 'jekyll-autoprefixer'
 gem 'html-proofer'
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (6.3.7)
-      execjs
     colorator (1.1.0)
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
@@ -19,7 +17,6 @@ GEM
     ethon (0.11.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
-    execjs (2.7.0)
     ffi (1.9.25)
     forwardable-extended (2.6.0)
     html-proofer (3.9.2)
@@ -48,8 +45,6 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-autoprefixer (1.0.1)
-      autoprefixer-rails (~> 6.3.6)
     jekyll-redirect-from (0.14.0)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
@@ -98,9 +93,8 @@ PLATFORMS
 DEPENDENCIES
   html-proofer
   jekyll
-  jekyll-autoprefixer
   jekyll-redirect-from
   jekyll_pages_api
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/_config.yml
+++ b/_config.yml
@@ -6,13 +6,6 @@ url: "" # the base hostname & protocol for your site
 logo: /assets/img/site-logo.svg
 feature_image: /assets/img/feature-background.jpg
 
-gems:
-  - jekyll-autoprefixer
-
-autoprefixer:
-  browsers:
-  - last 3 versions
-
 colors:
   background: '#ffffff'
   button:


### PR DESCRIPTION
This pull request fixes a typo in the `.gitlab-ci.yml` file that caused the runner to fail. It also adds back some fixes that @leebrian had for getting the runner to work.