### PR TITLE
Making changes to the events page and styling changes on the headers

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,0 +1,9 @@
+- title: OpenCDC Hackathon 2018
+  id: hackathon-2018
+  slug: hackathon-2018.html
+  description: Registration is now available for the OpenCDC Hackathon scheduled for October 3–4, 2018, and co-sponsored by the Office of the Chief Information Officer (OCIO) and the Division of Health Informatics and Surveillance (DHIS) in the Center for Surveillance, Epidemiology, and Laboratory Services (CSELS). Hosted by the Accelerator Team (XLR) in DHIS, the hackathon is open to all CDC employees, including FTEs, contractors, and fellows, interested in open source technologies, innovation, and collaboration at CDC.
+  image: hackathon-banner.png
+  date: October 3–4, 2018
+  location: CDC Roybal Campus, Building 19, Auditorium B1/B2
+  registration: https://go.usa.gov/xUfPG
+  type: hackathon

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en-us" class="theme-blue">
+
+{% include head.html %}
+
+<body class="no-js">
+  {% include header.html %}
+
+  <!-- Page Content Wrap -->
+  <div class="container d-flex flex-wrap body-wrapper bg-white">
+    <!-- Content -->
+    <main class="col-12 order-lg-2" role="main" aria-label="Main Content Area">
+      {% include nav.html %}
+      
+      <div class="opencdc-content">
+        {{ content }}
+      </div>
+
+      {% include disclaimer.html %}
+    </main>
+  </div>
+
+  {% include footer.html %}
+
+  {% include javascript.html %}
+</body>
+</html>

--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -3,12 +3,11 @@ $code-border-color: #979797;
 section.project {
   .section-header {
     h2 {
-      color: #555;
+      color: #205493;
     }
     img.section-image {
-      position: relative;
-      top: 20px;
-      margin: 0 0 0 10px;
+      position: absolute;
+      margin: -30px 0 0 10px;
       height: 80px;
     }
     p {
@@ -22,9 +21,19 @@ section.project {
   }
 
   .repos {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin: 0;
+
     .repo {
-      padding: 0 0 10px 0;
-      border-bottom: 1px solid $code-border-color;
+      border: 1px solid #e6e6e6;
+      background-color: #f5f5f5;
+      margin: 20px 0;
+      padding: 20px;
+      flex: 1;
+      min-width: 48%;
+      max-width: 48%;
 
       a {
         color: #555;
@@ -33,6 +42,18 @@ section.project {
 
         &:hover {
           color: #777;
+        }
+      }
+
+      .docker-image {
+        img {
+          height: 25px;
+        }
+
+        &:hover {
+          img {
+            opacity: 0.8;
+          }
         }
       }
 
@@ -53,10 +74,23 @@ section.project {
         padding: 10px;
         display: inline-block;
         color: inherit;
+        font-size: 1rem;
+        margin: 0 0 10px 0;
       }
 
       p {
         color: #7E7E7E;
+      }
+    }
+  }
+}
+
+@media (max-width: 1400px) {
+  section.project {
+    .repos {
+      .repo {
+        min-width: 100%;
+        max-width: 100%;
       }
     }
   }

--- a/_sass/_events.scss
+++ b/_sass/_events.scss
@@ -1,158 +1,56 @@
-$host:'http://s3-us-west-2.amazonaws.com/s.cdpn.io/397014/';
-
-$big-stone:#152536;
-$white:#fff;
-$smalt-blue:#4e958b;
-$maroon-flush:#C32361;
-$black:#000;
-$lite-grey:rgba($black, .2);
-$lite-big-stone:rgba($big-stone, .7);
-
-$card-width:300px;
-$card-height:420px;
-
-$thumb-height:260px;
-
-$border-radius:3px;
-$box-shadow:0 1px 4px rgba($black, .3);
-$transition: cubic-bezier(.17,.67,.5,1.03);
-$timing-1:.4s .15s;
-$timing-2:.5s .25s;
-
-$grotesque-black:'Grotesque Black', sans-serif;
-$grotesque-regular:'Grotesque', sans-serif;
-$merriweather:'Merriweather', sans-serif;
-
-$new-york-city:'#{$host}new-york-city.png';
-$flag:'#{$host}flag.png';
-
-@mixin pos($pos, $left:null, $top:null, $right:null, $bottom:null) {
-	position:$pos;
-	left:$left;
-	@if $top { top: $top; }
-	@if $left { left: $left; }
-	@if $right { right: $right; }
-	@if $bottom { bottom: $bottom; }
-}
-
-@mixin size($width, $height) {
-	width:$width;
-	height:$height;
-}
-
-
-article.card {
-
-	@include size($card-width, $card-height);
-	// transform:translate(-50%, -50%) translateZ(0);
-  text-align:left;
-	border-radius:$border-radius;
-  margin: 10px;
-	box-shadow:$box-shadow;
-	overflow:hidden;
-	.thumb {
-		@include size(auto, $thumb-height);
-		background: no-repeat center;
-		background-size:cover;
-		border-radius:$border-radius;
-	}
-	.infos {
-		@include size(auto, $card-height);
-		position:relative;
-		padding:14px 24px;
-		background:$white;
-		transition:$timing-1 $transition;
-		.title {
-			position:relative;
-			margin: 10px 0;
-			letter-spacing: 3px;
-			color:$big-stone;
-			font-family: $grotesque-black;
-			// font-size: 1rem;
-			text-transform: uppercase;
-			text-shadow: 0 0 0px lighten($big-stone, 20);
+.events {
+	.event {
+		.section-header {
+			h2 {
+				a:hover {
+					opacity: 0.8;
+					outline: none;
+				}
+			}
 		}
-		.event-flag {
-			@include pos(absolute, $top:50%, $right: 0);
-			transform:translateY(-50%);
-			@include size(35px, 23px);
-			background:url($flag) no-repeat top right;
-			background-size:100% auto;
-			display:inline-block;
-		}
-		.date, .location {
-			margin-bottom: 5px;
-			text-transform: uppercase;
-			// font-size: .85rem;
-			color:$lite-big-stone;
-			font-family: $grotesque-regular;
-		}
-		.location {
-			display:inline-block;
-      margin-top: 1px;
-			margin-bottom: 5px;
-			padding-bottom:10px;
-			border-bottom:1px solid $lite-grey;
-			opacity:0;
-			transition:$timing-2 $transition;
-		}
-		.txt {
-			font-family: $merriweather;
-			line-height: 2;
-			// font-size: .95rem;
-			color:$lite-big-stone;
-			opacity:0;
-			transition:$timing-2 $transition;
-		}
-		.details {
-			@include pos(absolute, $left:0, $bottom:0);
-			margin: 10px 0;
-			padding:20px 24px;
-			letter-spacing: 1px;
-			color:$smalt-blue;
-			font-family: $grotesque-black;
-			// font-size: .9rem;
-			text-transform: uppercase;
-			text-decoration: none;
-			cursor:pointer;
-			opacity:0;
-			transition:$timing-2 $transition;
+		.section-content {
+			display: flex;
+
+			.section-side {
+				flex: 1;
+				background-color: #eee;
+				padding: 20px;
+
+				h4 {
+					margin: 0;
+				}
+
+				a.register {
+					background-color: $button-color;
+					padding: 10px;
+					width: 100%;
+					display: block;
+					color: white;
+					text-align: center;
+					text-transform: uppercase;
+					text-decoration: none;
+
+					&:hover {
+						opacity: 0.8;
+					}
+				}
+			}
+
+			.section-main {
+				flex: 4;
+
+				img.section-image {
+					width: 100%;
+				}
+
+				.description {
+					padding: 20px;
+					
+					p {
+						margin: 10px 0;
+					}
+				}
+			}
 		}
 	}
-	&:hover .infos {
-		transform:translateY(-$thumb-height);
-		.location, .txt, .details {
-			opacity:1;
-		}
-	}
-}
-article.card-featured {
-	@extend .card;
-	width: 100%;
-}
-
-.event-hero {
-padding: 30rem;
-background-position: center;
-background-size: cover;
-}
-
-.rsvp-bar {
-    background: #F8F8FA;
-    display: flex;
-    -webkit-box-pack: center;
-    justify-content: space-around;
-}
-
-.rsvp--block {
-	display: block;
-	position: relative;
-	padding: 40px 0;
-}
-
-.material-icons {
-    position: relative;
-    top: -.1em;
-    vertical-align: middle;
-    padding-right: .25em;
 }

--- a/events/hackathon-2018.md
+++ b/events/hackathon-2018.md
@@ -1,7 +1,7 @@
 ---
-layout: page
+layout: event
 title: Events
-permalink: /events.html
+permalink: /events/hackathon-2018.html
 category: events
 banner-heading: Events
 banner-text: Here you will find information on events and resources relating to CDC Open Technology. Periodically, we will host hackathons to find innovative solutions for public health issues using technology and data. We will also host webinars and other events to share information on CDC Open Technology and available resources. Please keep checking back to see upcoming events.
@@ -9,9 +9,6 @@ banner-button-text:
 banner-button-link:
 banner-button-title:
 ---
-
-### Hackathons
-In order to facilitate the education and promotion of CDC Open Technology, we will regularly hold hackathons and encourage participation from the public.
 
 #### OpenCDC Hackathon: Oct. 3rd + 4th
 ![OpenCDC Hackathon October 3rd and 4th 2018][hackathon-banner]
@@ -26,13 +23,6 @@ To register, please complete the form at [https://go.usa.gov/xUfPG](https://go.u
  
 If you have questions or need more information, please contact the DHIS Accelerator Team at [xlr@cdc.gov](mailto:xlr@cdc.gov) or read the [CDC Connects article](http://intranet.cdc.gov/connects/2017/08/29/hackathon-aims-to-modernize-cdc-software/) about the team’s last hackathon held May 23–24, 2017.
 
-Download the [hackathon poster here](assets/pdf/2018-CDC-hackathon.pdf).
+Download the [hackathon poster here](/assets/pdf/2018-CDC-hackathon.pdf).
 
-### Webinars
-Interactive webinars are a great resource for sharing information and demonstrating CDC Open Technology. Please check back here to find more information on upcoming webinars.
-
-### Resources
-We have gathered resources such as tutorials, videos, and other information to help you interact with CDC Open Technology. Please browse through the resources below.
-
-
-[hackathon-banner]: assets/img/hackathon-banner.png "OpenCDC Hackathon October 3rd and 4th 2018"
+[hackathon-banner]: /assets/img/hackathon-banner.png "OpenCDC Hackathon October 3rd and 4th 2018"

--- a/events/hackathon-2018.md
+++ b/events/hackathon-2018.md
@@ -23,6 +23,6 @@ To register, please complete the form at [https://go.usa.gov/xUfPG](https://go.u
  
 If you have questions or need more information, please contact the DHIS Accelerator Team at [xlr@cdc.gov](mailto:xlr@cdc.gov) or read the [CDC Connects article](http://intranet.cdc.gov/connects/2017/08/29/hackathon-aims-to-modernize-cdc-software/) about the team’s last hackathon held May 23–24, 2017.
 
-Download the [hackathon poster here](/assets/pdf/2018-CDC-hackathon.pdf).
+Download the [hackathon poster here]({{ site.baseurl }}/assets/pdf/2018-CDC-hackathon.pdf).
 
-[hackathon-banner]: /assets/img/hackathon-banner.png "OpenCDC Hackathon October 3rd and 4th 2018"
+[hackathon-banner]: {{ site.baseurl }}/assets/img/hackathon-banner.png "OpenCDC Hackathon October 3rd and 4th 2018"

--- a/pages/code.html
+++ b/pages/code.html
@@ -25,13 +25,15 @@ banner-button-title:
   <div class="repos">
   {% for repo in section.repos %}
     <div class="repo">
+      {% if repo.docker %}
+        <a href="https://hub.docker.com/r/{{ repo.docker }}" target="_blank" class="pull-right docker-image">
+          <img src="{{ site.baseurl }}/assets/img/docker.svg" alt="Docker Image Available" />
+        </a>
+      {% endif %}
       <div class="title">
         <a href="https://github.com/CDCgov/{{ repo.url }}" target="_blank"><h3>{{ repo.title }}</h3></a>
       </div>
       <div class="resources">
-        {% if repo.docker %}
-          <a href="https://hub.docker.com/r/{{ repo.docker }}" target="_blank" class="pull-right"><img src="{{ site.baseurl }}/assets/img/docker.svg" alt="Docker Image Available" /></a>
-        {% endif %}
         <a href="https://github.com/CDCgov/{{ repo.url }}" target="_blank">https://github.com/CDCgov/{{ repo.url }}</a>
       </div>
       <p class="description">{{ repo.description }}</p>

--- a/pages/events.html
+++ b/pages/events.html
@@ -1,0 +1,43 @@
+---
+layout: page
+title: Events
+permalink: /events.html
+category: events
+banner-heading: Events
+banner-text: Here you will find information on events and resources relating to CDC Open Technology. Periodically, we will host hackathons to find innovative solutions for public health issues using technology and data. We will also host webinars and other events to share information on CDC Open Technology and available resources. Please keep checking back to see upcoming events.
+banner-button-text:
+banner-button-link:
+banner-button-title:
+---
+
+<div class="events">
+  {% for section in site.data.events %}
+  <section class="opencdc-section event" id="{{ section.id }}">
+    <div class="section-header">
+      <h2><a href="{{ site.baseurl }}/events/{{section.slug}}">{{section.title}}</a></h2>
+    </div>
+    <div class="section-content">
+      <div class="section-side">
+        <h4>Event Type</h4>
+        <p>{{section.type}}</p>
+        <h4>When</h4>
+        <p>{{section.date}}</p>
+        <h4>Location</h4>
+        <p>{{section.location}}</p>
+        <a href="{{section.registration}}" class="register" target="_blank">Register</a>
+      </div>
+      <div class="section-main">
+        {% if section.image %}
+          <figure>
+            <img src="{{ site.baseurl }}/assets/img/{{ section.image }}" alt="{{section.title}}" class="section-image" />
+          </figure>
+        {% endif %}
+        <div class="description">
+          <p class="tagline">{{ section.description }}</p>
+          <a href="{{ site.baseurl }}/events/{{section.slug}}">Read More</a>
+        </div>
+      </div>
+    </div>
+  </section>
+  {% endfor %}    
+</div>


### PR DESCRIPTION
This pull request is to redesign the code.html and events.html pages so that the layout is clearer for which code repositories belong to different projects and grouping events into a single stream with different types of events like if it's a hackathon, webinar, etc.

This pull request also includes changes for styling to keep header colors consistent (blue vs grey). Other changes include a new `events.yml` for adding events easily, a new `events.html` as a layout and a new `events` folder for having detail pages for each event.