### PR TITLE
More responsive improvements

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -132,13 +132,12 @@
               <div class="list-group indicator-plus">
                 <ul></ul>
               </div>
-              <a class="list-group-item mobile-section-nav-foot" href="#">
+              <a class="list-group-item mobile-section-nav-foot" href="https://www.cdc.gov/od/ocio/index.htm">
                 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xmlns:xlink="http://www.w3.org/1999/xlink">
                   <title>home4</title>
                   <path d="M9.984 20.016h-4.969v-8.016h-3l9.984-9 9.984 9h-3v8.016h-4.969v-6h-4.031v6z"></path>
                 </svg>
-
-                <span class="mobile-foot-title">TP Docs Home</span>
+                <span class="mobile-foot-title">OCIO Home</span>
               </a>
             </nav>
           </div>

--- a/_includes/hero-header.html
+++ b/_includes/hero-header.html
@@ -3,10 +3,10 @@
     <section class="hero-content">
       {% if page.layout == 'home' %}
       <div class="opencdc-grid intro">
-        <div class="opencdc-one-half">
+        <div class="opencdc-one-half text">
           <h1>{{ page.hero-text }}</h1>
         </div>
-        <div class="opencdc-one-half">
+        <div class="opencdc-one-half graphic">
           <a href="{{ '/code.html' | prepend: site.baseurl }}">
             <img class="" src="{{ site.baseurl }}/assets/img/img-hero-intro.svg" alt="hero api image">
           </a>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -15,8 +15,7 @@ body{
   margin-bottom: -20px;
 }
 #content{
-  padding-bottom: $footer-height;
-  min-height: 95vh;
+  padding-bottom: 1rem;
 }
 #footer {
 	width:100%;

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -11,3 +11,7 @@
 	vertical-align:middle;
 	text-align:center;
 }
+
+.theme-blue nav .mobile-section-nav a.mobile-section-nav-foot span {
+	color: #fff;
+}

--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -10,6 +10,7 @@
 .hero-border {
   position: absolute;
   bottom: 0;
+  right: 0;
   width: 100%;
   height: 140px;
   /* set height to pixels if you want angle to change with screen width */

--- a/_sass/_responsive.scss
+++ b/_sass/_responsive.scss
@@ -1,4 +1,4 @@
-@media only screen and (max-width: 600px) {
+@media only screen and (max-width: 780px) {
   #content {
     padding-bottom: 20px;
   }
@@ -42,8 +42,19 @@
   section.project .repos .repo .license {
     text-align: left;
   }
-  .opencdc-search [type=search], .opencdc-search .opencdc-search-input {
-    width: 160px;
+  .opencdc-search {
+    margin-bottom: 50px;
+
+    [role=search] {
+      [type=search], 
+      .opencdc-search-input {
+        width: 55%;
+      }
+
+      button {
+        width: 35%;
+      }
+    }
   }
   .opencdc-grid .opencdc-whole-row {
     max-width: 100%;
@@ -72,7 +83,11 @@
     padding: 1rem 2rem;
 
     .intro  {
-      h1 {
+      a img {
+        height: 80%;
+        margin: 0.5rem auto;
+      }
+      .text {
         display: none;
       }
     }


### PR DESCRIPTION
This pull request suggests a few more improvements on the responsiveness and also increases the media query to go from `780px` instead of `600px` which corrects for some UI issues on small tablets. This also removes some of the excess white space that a lot of the pages have due to a `min-height` and large `padding` on the `#content` styles. This proposes to take these out and go with a more modest spacing.