### PR TITLE
Removed all archived Foundation Services and adjusted FDNS descriptions

### DIFF
--- a/_data/code.yml
+++ b/_data/code.yml
@@ -59,101 +59,16 @@
   image: fdns-logo.svg
   tagline: Foundation Services Open Source Projects
   repos:
-    - title: FDNS
-      url: https://github.com/CDCgov/fdns
-      description: This is a central repository with high level information on Foundation Services, tutorials, example code, etc.
-      tags:
-        - microservice
-      license: Apache License 2.0
     - title: FDNS-UI-React
       url: https://github.com/CDCgov/fdns-ui-react
-      description: This is the repository with the a front-end library built in React, will also need to publish to NPM.
+      description: A collection of reusable React components for quickly building modern and accessible web applications.
       tags:
-        - microservice
         - javascript
         - react
       license: Apache License 2.0
-    - title: FDNS-JS-SDK
-      url: https://github.com/CDCgov/fdns-js-sdk
-      description: This is the repository with the JavaScript SDK for Foundation Services, will also need to publish to NPM.
-      tags:
-        - microservice
-        - javascript
-      license: Apache License 2.0
-    - title: FDNS-Java-SDK
-      url: https://github.com/CDCgov/fdns-java-sdk
-      description: This is the repository with the Java SDK for Foundation Services, will also need to publish to Maven.
-      tags:
-        - microservice
-        - java
-      license: Apache License 2.0
-    - title: FDNS-Rules-Engine
-      url: https://github.com/CDCgov/fdns-rules-engine
-      description: This the repository with the Java Library for the Business Rules Engine, will also need to publish to Maven.
-      tags:
-        - microservice
-        - java
-      license: Apache License 2.0
-    - title: FDNS-MS-Gateway
-      url: https://github.com/CDCgov/fdns-ms-gateway
-      description: This is the repository with the API gateway to connect other microservices together.
-      tags:
-        - microservice
-        - java
-        - springboot
-      license: Apache License 2.0
-    - title: FDNS-MS-Storage
-      url: https://github.com/CDCgov/fdns-ms-storage
-      description: This is the repository with the Storage layer for the Data Lake. This is the immutable layer.
-      tags:
-        - microservice
-        - java
-        - springboot
-      license: Apache License 2.0
-    - title: FDNS-MS-Object
-      url: https://github.com/CDCgov/fdns-ms-object
-      description: This is the repository with the Object layer for the Data Lake. This is the mutable layer.
-      tags:
-        - microservice
-        - java
-        - springboot
-        - mongodb
-      license: Apache License 2.0
-    - title: FDNS-MS-Indexing
-      url: https://github.com/CDCgov/fdns-ms-indexing
-      description: This is the repository with the Indexing layer for the Data Lake. This is the navigation layer.
-      tags:
-        - microservice
-        - java
-        - springboot
-      license: Apache License 2.0
     - title: FDNS-MS-HL7-Utils
       url: https://github.com/CDCgov/fdns-ms-hl7-utils
-      description: This is the repository with the HL7 utilities service to parse, validate and generate sample HL7 data.
-      tags:
-        - microservice
-        - java
-        - springboot
-      license: Apache License 2.0
-    - title: FDNS-MS-CDA-Utils
-      url: https://github.com/CDCgov/fdns-ms-cda-utils
-      description: This is the repository with the CDA utilities service to parse, validate and generate sample CDA data.
-      tags:
-        - microservice
-        - java
-        - springboot
-      license: Apache License 2.0
-    - title: FDNS-MS-Combiner
-      url: https://github.com/CDCgov/fdns-ms-combiner
-      description: This is the repository with the Combiner service to combine JSON files into a single CSV or XLSX file.
-      tags:
-        - microservice
-        - java
-        - springboot
-      license: Apache License 2.0
-    - title: FDNS-MS-Rules
-      url: https://github.com/CDCgov/fdns-ms-rules
-      description: This is the repository with the Business Rules Engine for ingesting and validating JSON files.
+      description: This is the repository with the HL7 utilities service to parse, validate, and generate sample HL7 data.
       tags:
         - microservice
         - java


### PR DESCRIPTION
Most of the current Foundation Services repositories on CDC's GitHub have been archived and are unlikely to see further development. I'd therefore like to remove these entries from OpenCDC. Additionally, I cleaned up `fdns-ui-react`'s description to fix grammar issues and to make it clearer what benefits the library offers.