### PR TITLE
Remove cdc.gov/data from data.yml

### DIFF
--- a/_data/data.yml
+++ b/_data/data.yml
@@ -6,10 +6,6 @@
   id: chronicdata-cdc-gov
   url: https://chronicdata.cdc.gov
   tagline: "Chronic Disease and Health Promotion Data & Indicators"
-- title: www.CDC.gov/data
-  id: cdc-gov-data-tools
-  url: https://www.cdc.gov/data
-  tagline: "Data, Statistics, and Tools by CDC Topic Area"
 - title: National Center for Health Statistics
   id: nchs
   url: https://www.cdc.gov/nchs/data_access/ftp_data.htm


### PR DESCRIPTION
As of 2024-03-21, https://www.cdc.gov/data is a deadlink
> The page you're looking for was not found.

![image](https://github.com/CDCgov/opencdc/assets/4275722/edf39aa4-4e29-4a69-b986-5e5c4381e35b)

